### PR TITLE
Add %fortranbegin section

### DIFF
--- a/Lib/fortran/fortran.swg
+++ b/Lib/fortran/fortran.swg
@@ -21,8 +21,11 @@
 #define %fortranprepend       %feature("fortranprepend")
 #define %clearfortranprepend  %feature("fortranprepend","")
 
-#define %fortranappend         %feature("fortranappend")
-#define %clearfortranappend    %feature("fortranappend","")
+#define %fortranappend        %feature("fortranappend")
+#define %clearfortranappend   %feature("fortranappend","")
+
+#define %fortranbegin         %insert("fortranbegin")
+
 
 #define %parameter      %feature("parameter")
 #define %noparameter    %feature("parameter","0")

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -368,6 +368,7 @@ class FORTRAN : public Language
 
     // Injected into .cxx file
     String* f_begin; //!< Very beginning of output file
+    String* f_fortranbegin; //!< Very beginning of output file
     String* f_runtime; //!< SWIG runtime code
     String* f_header; //!< Declarations and inclusions from .i
     String* f_wrapper; //!< C++ Wrapper code
@@ -402,6 +403,7 @@ class FORTRAN : public Language
     virtual int staticmemberfunctionHandler(Node *n);
     virtual int staticmembervariableHandler(Node *n);
     virtual int importDirective(Node *n);
+    virtual int insertDirective(Node *n);
     virtual int enumDeclaration(Node *n);
     virtual int constantWrapper(Node *n);
     virtual int classforwardDeclaration(Node *n);
@@ -504,6 +506,10 @@ int FORTRAN::top(Node *n)
     f_begin = NewStringEmpty();
     Swig_register_filebyname("begin", f_begin);
 
+    // run time code (beginning of .f90 file)
+    f_fortranbegin = NewString("");
+    Swig_register_filebyname("fortranbegin", f_fortranbegin);
+
     // run time code (beginning of .cxx file)
     f_runtime = NewStringEmpty();
     Swig_register_filebyname("runtime", f_runtime);
@@ -573,6 +579,7 @@ int FORTRAN::top(Node *n)
     Delete(f_wrapper);
     Delete(f_header);
     Delete(f_runtime);
+    Delete(f_fortranbegin);
     Delete(f_begin);
 
     return SWIG_OK;
@@ -637,6 +644,7 @@ void FORTRAN::write_module()
     Swig_banner_target_lang(out, "!");
 
     // Write module
+    Dump(f_fortranbegin, out);
     Printv(out, "module ", d_module, "\n"
                 " use, intrinsic :: ISO_C_BINDING\n",
                 f_imports,
@@ -1521,6 +1529,26 @@ String* FORTRAN::makeParameterName(Node *n, Parm *p,
         name = NewStringf("%s%d", origname, arg_num++);
     }
     return name;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * \brief Hook for insert directive
+ *
+ * \param[in] n Function node
+ */
+int FORTRAN::insertDirective(Node *n) {
+    String *code = Getattr(n, "code");
+    String *section = Getattr(n, "section");
+
+    if ((!ImportMode) && (Cmp(section, "fortranbegin") == 0)) {
+        // We are in the %fortranbegin section, inject the code
+        Printv(f_fortranbegin, code, NIL);
+    } else {
+        // Do the default thing
+        Language::insertDirective(n);
+    }
+    return SWIG_OK;
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This would allow to insert code in the beginning of a Fortran module
file, similar how `%begin` inserts the code in the beginning of wrapper.

This code was originally in sethrj/swig#17 PR, but then magically
disappeared. This is a faithful reproduction.