### PR TITLE
Fix C_LOC usage for stricter standards compliance

### DIFF
--- a/Lib/fortran/exception.i
+++ b/Lib/fortran/exception.i
@@ -226,21 +226,10 @@ typedef const std::string& Swig_Err_String;
 %typemap(ftype, out="character(kind=C_CHAR, len=:), allocatable") STRING_TYPES
 "character(kind=C_CHAR, len=*), target"
 
-// Fortran proxy translation code: temporary variables for output
-%typemap(foutdecl) STRING_TYPES
+// Fortran proxy translation code: convert from char array to Fortran string
+%typemap(fout, fragment="SwigfCharArrayToString") STRING_TYPES
 %{
- integer(kind=C_SIZE_T) :: $1_i
- character(kind=C_CHAR), dimension(:), pointer :: $1_chars
-%}
-
-// Fortran proxy translation code: convert from imtype $1 to ftype $result
-%typemap(fout) STRING_TYPES
-%{
-  call c_f_pointer($1%data, $1_chars, [$1%size])
-  allocate(character(kind=C_CHAR, len=$1%size) :: $result)
-  do $1_i=1,$1%size
-    $result($1_i:$1_i) = $1_chars($1_i)
-  enddo
+  call swigf_chararray_to_string($1, $result)
 %}
 
 #undef STRING_TYPES

--- a/Lib/fortran/forfragments.swg
+++ b/Lib/fortran/forfragments.swg
@@ -65,6 +65,7 @@ end type
 
 // Add function to return allocatable array from assumed-length char
 %fragment("SwigfStringToCharArray", "fwrapper",
+          fragment="SwigfArrayWrapper",
           noblock="1") %{
 subroutine swigf_string_to_chararray(string, chars, wrap)
   use, intrinsic :: ISO_C_BINDING
@@ -84,6 +85,7 @@ end subroutine
 
 // Add function to return allocatable string from char array
 %fragment("SwigfCharArrayToString", "fwrapper",
+          fragment="SwigfArrayWrapper",
           noblock="1") %{
 subroutine swigf_chararray_to_string(wrap, string)
   use, intrinsic :: ISO_C_BINDING

--- a/Lib/fortran/forfragments.swg
+++ b/Lib/fortran/forfragments.swg
@@ -37,6 +37,7 @@ enum, bind(c)
   enumerator :: SwigfUnknownEnum = -1
 end enum
 %}
+
 //---------------------------------------------------------------------------//
 // ARRAY WRAPPER
 //---------------------------------------------------------------------------//
@@ -60,6 +61,42 @@ type, bind(C) :: SwigfArrayWrapper
   type(C_PTR), public :: data
   integer(C_SIZE_T), public :: size
 end type
+%}
+
+// Add function to return allocatable array from assumed-length char
+%fragment("SwigfStringToCharArray", "fwrapper",
+          noblock="1") %{
+subroutine swigf_string_to_chararray(string, chars, wrap)
+  use, intrinsic :: ISO_C_BINDING
+  character(kind=C_CHAR, len=*), intent(IN) :: string
+  character(kind=C_CHAR), dimension(:), target, allocatable, intent(OUT) :: chars
+  type(SwigfArrayWrapper), intent(OUT) :: wrap 
+  integer(kind=C_SIZE_T) :: i
+
+  allocate(character(kind=C_CHAR) :: chars(len(string)))
+  do i=1,size(chars)
+    chars(i) = string(i:i)
+  enddo
+  wrap%data = c_loc(chars)
+  wrap%size = size(chars)
+end subroutine
+%}
+
+// Add function to return allocatable string from char array
+%fragment("SwigfCharArrayToString", "fwrapper",
+          noblock="1") %{
+subroutine swigf_chararray_to_string(wrap, string)
+  use, intrinsic :: ISO_C_BINDING
+  type(SwigfArrayWrapper), intent(IN) :: wrap 
+  character(kind=C_CHAR, len=:), allocatable, intent(OUT) :: string
+  character(kind=C_CHAR), dimension(:), pointer :: chars
+  integer(kind=C_SIZE_T) :: i
+  call c_f_pointer(wrap%data, chars, [wrap%size])
+  allocate(character(kind=C_CHAR, len=wrap%size) :: string)
+  do i=1, wrap%size
+    string(i:i) = chars(i)
+  enddo
+end subroutine
 %}
 
 //---------------------------------------------------------------------------//

--- a/Lib/fortran/typemaps.i
+++ b/Lib/fortran/typemaps.i
@@ -114,28 +114,16 @@
   %typemap(ftype, out="character(kind=" CHARTYPE "), dimension(:), pointer") PAIR_TYPE
     "character(kind=" CHARTYPE ", len=*), target"
 
-%typemap(findecl) PAIR_TYPE
-%{
- integer(kind=C_SIZE_T) :: $1_i
- character(kind=C_CHAR), dimension(:), allocatable, target :: $1_chars
-%}
+  %typemap(findecl) PAIR_TYPE
+  %{
+    character(kind=C_CHAR), dimension(:), allocatable, target :: $1_chars
+  %}
 
   // Fortran proxy translation code: copy var-length character type to
   // fixed-length character array
-  %typemap(fin) PAIR_TYPE
+  %typemap(fin, fragment="SwigfStringToCharArray", noblock=1) PAIR_TYPE
   %{
-  allocate(character(kind=C_CHAR) :: $1_chars(len($input)))
-  do $1_i=1,size($1_chars)
-    $1_chars($1_i) = $input($1_i:$1_i)
-  enddo
-  $1%data = c_loc($1_chars)
-  $1%size = size($1_chars)
-  %}
-
-  // Free allocated memory
-  %typemap(ffreearg) PAIR_TYPE
-  %{
-  deallocate($1_chars)
+    call swigf_string_to_chararray($input, $1_chars, $1)
   %}
 
   #undef PAIR_TYPE

--- a/Lib/fortran/typemaps.i
+++ b/Lib/fortran/typemaps.i
@@ -69,8 +69,12 @@
   // contiguous arrays are passed. Conceivably we could improve this to use
   // strided access by also passing c_loc($input(2)) and doing pointer
   // arithmetic.
+  %typemap(findecl) PAIR_TYPE
+  FTYPE ", pointer :: $1_view"
+
   %typemap(fin) PAIR_TYPE
-    %{$1%data = c_loc($input(1))
+    %{$1_view => $input(1)
+      $1%data = c_loc($1_view)
       $1%size = size($input)%}
 
   // Instantiate type so that SWIG respects %novaluewrapper


### PR DESCRIPTION
Fixes #40  . Now all the examples compile in GCC 4.8.5.