### PR TITLE
Add automated BIND(C) wrapping to structs

### DIFF
--- a/Examples/fortran/simpleclass/SimpleClass.cc
+++ b/Examples/fortran/simpleclass/SimpleClass.cc
@@ -121,6 +121,11 @@ const SimpleClass& get_class()
     return g_globalclass;
 }
 
+void print_struct(const BasicStruct& s)
+{
+    cout << "Struct " << &s << " has foo=" << s.foo
+         << ", bar=" << s.bar << endl;
+}
 //---------------------------------------------------------------------------//
 // end of simple_class/SimpleClass.cc
 //---------------------------------------------------------------------------//

--- a/Examples/fortran/simpleclass/SimpleClass.hh
+++ b/Examples/fortran/simpleclass/SimpleClass.hh
@@ -14,7 +14,8 @@
 //! Simple public struct
 struct BasicStruct
 {
-    int val;
+    int    foo;
+    double bar;
 };
 
 //===========================================================================//
@@ -86,6 +87,8 @@ const SimpleClass& get_class();
 
 //! Pass class as a parameter
 void set_class_by_copy(SimpleClass c);
+
+void print_struct(const BasicStruct& s);
 
 //---------------------------------------------------------------------------//
 #endif // simple_class_SimpleClass_hh

--- a/Examples/fortran/simpleclass/simple_class.i
+++ b/Examples/fortran/simpleclass/simple_class.i
@@ -17,7 +17,6 @@
 
 #ifdef SWIGFORTRAN
 
-
 %{
 #include <iostream>
 using std::cout;
@@ -102,6 +101,9 @@ end subroutine
 };
 
 %feature("new") emit_class;
+
+// Make BasicStruct a fortran-accessible struct.
+%fortran_bindc_struct(BasicStruct);
 
 // %rename(SimpleClassDerp) SimpleClass;
 %include "SimpleClass.hh"

--- a/Examples/fortran/simpleclass/test.f90
+++ b/Examples/fortran/simpleclass/test.f90
@@ -68,10 +68,9 @@ subroutine test_class()
     write(0, *) "Done!"
 
     write(0, *) "Building struct..."
-    call s%create()
-    call s%set_val(4)
-    write(0, *) "Values:", s%get_val()
-    call s%release()
+    s%foo = 4
+    s%bar = 9.11d0
+    call print_struct(s)
 end subroutine
 
 end program

--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -334,6 +334,7 @@ CPP_TEST_CASES += \
 	overload_subtype \
 	overload_template \
 	overload_template_fast \
+	pod_struct \
 	pointer_reference \
 	preproc_constants \
 	primitive_ref \

--- a/Examples/test-suite/fortran/ret_by_value_runme.f90
+++ b/Examples/test-suite/fortran/ret_by_value_runme.f90
@@ -13,16 +13,17 @@ program ret_by_value_runme
 
   test_val = get_test()
 
-  int = test_val%get_myInt()
-  short = test_val%get_myShort()
+  int = test_val%myInt
+  short = test_val%myShort
 
-  if(test_val%get_myInt() /= 100) then
+  if(test_val%myInt /= 100) then
     write(*,*)"Wrong value for %myInt",100
     okay = .false.
   endif
 
-  if(test_val%get_myShort() /= 200) then
+  if(test_val%myShort /= 200) then
     write(*,*)"Wrong value for "
+    okay = .false.
   endif
 
 

--- a/Examples/test-suite/pod_struct.i
+++ b/Examples/test-suite/pod_struct.i
@@ -1,0 +1,36 @@
+%module pod_struct
+
+#ifdef SWIGFORTRAN
+// Treat the struct as a native fortran struct rather than as a class with
+// getters/setters.
+%fortran_bindc_struct(SimpleStruct);
+#endif
+
+
+%inline %{
+
+typedef double (*BinaryOp)(double x, double y);
+
+struct SimpleStruct {
+    int i;
+    double d;
+    char c;
+    BinaryOp funptr;
+    void* v;
+    const char* s;
+};
+
+void set_val(SimpleStruct s);
+void set_ptr(const SimpleStruct* s);
+void set_ref(const SimpleStruct& s);
+
+void get_ptr_arg(SimpleStruct* s);
+void get_ref_arg(SimpleStruct& s);
+
+SimpleStruct get_val();
+SimpleStruct* get_ptr();
+SimpleStruct& get_ref();
+
+const SimpleStruct* get_cptr();
+const SimpleStruct& get_cref();
+%}

--- a/Examples/test-suite/ret_by_value.i
+++ b/Examples/test-suite/ret_by_value.i
@@ -4,6 +4,12 @@
 
 %warnfilter(SWIGWARN_RUBY_WRONG_NAME) test; /* Ruby, wrong class name */
 
+#ifdef SWIGFORTRAN
+// Treat the struct as a native fortran struct rather than as a class with
+// getters/setters.
+%fortran_bindc_struct(test);
+#endif
+
 %inline %{
 
 typedef struct {

--- a/Lib/fortran/forkw.swg
+++ b/Lib/fortran/forkw.swg
@@ -7,12 +7,12 @@
  */
 //---------------------------------------------------------------------------//
 
-// By default SWIG gives these underscore prefix/suffix
 #ifdef __cplusplus
+// Give valid names to pointer-like operations
 %rename(deref) *::operator->;
 %rename(ref)   *::operator*();
-%rename(ref)   *::operator*() const;
 
+// By default SWIG gives these underscore prefix/suffix
 %keywordwarn("'create' is reserved for SWIG constructors",
              rename="create_") "*::create";
 %keywordwarn("'release' is reserved for SWIG destructors",

--- a/Lib/fortran/fortypemaps.swg
+++ b/Lib/fortran/fortypemaps.swg
@@ -312,6 +312,27 @@ FORT_SIMPLE_TYPEMAP(enum SWIGTYPE, int, "integer(C_INT)",
 #endif
 
 //---------------------------------------------------------------------------//
+// BIND(C) STRUCT TYPES
+//---------------------------------------------------------------------------//
+/*!
+ * \def FORT_BINDC_STRUCT
+ * \brief Add a typemap for a fundamental built-in type.
+ *
+ * The C++ and C types are the same in this case.
+ */
+%define %fortran_bindc_struct(CTYPE)
+  // Mark the class as being C-bound
+  %feature("fortran:bindc") CTYPE;
+  // Remove constructors and destructors
+  %nodefaultctor CTYPE;
+  %nodefaultdtor CTYPE;
+  // Interface code has to "import' the class type
+  %typemap(imimport) CTYPE, CTYPE*, CTYPE& "$fclassname"
+  // Bound structs act just like simple types
+  FORT_SIMPLE_TYPEMAP(CTYPE, CTYPE, "type($fclassname)", "type($fclassname)")
+%enddef
+
+//---------------------------------------------------------------------------//
 // OPAQUE POINTERS
 //---------------------------------------------------------------------------//
 /*!

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2009,7 +2009,8 @@ int FORTRAN::membervariableHandler(Node *n)
             return SWIG_NOWRAP;
         }
 
-        Printv(f_ftypes, " ", im_typestr, ", public :: ", symname, "\n", NULL);
+        Printv(f_ftypes, "  ", im_typestr, ", public :: ", symname, "\n",
+               NULL);
     }
     else
     {

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -1181,6 +1181,7 @@ void FORTRAN::imfuncWrapper(Node *n)
 {
     // Name of the C wrapper function
     String* wname = Getattr(n, "wrap:name");
+    String* cpp_return_type = Getattr(n, "type");
 
     Wrapper* imfunc = NewFortranWrapper();
 
@@ -1203,6 +1204,7 @@ void FORTRAN::imfuncWrapper(Node *n)
     String* imimport = Swig_typemap_lookup("imimport", n, im_return_str, NULL);
     if (imimport)
     {
+        this->replace_fclassname(cpp_return_type, imimport);
         Setattr(imimport_hash, imimport, "1");
     }
 
@@ -1262,6 +1264,7 @@ void FORTRAN::imfuncWrapper(Node *n)
     {
         // Declare dummy return value if it's a function
         Printv(imfunc->def, " &\n     result(fresult)", NULL);
+        this->replace_fclassname(cpp_return_type, im_return_str);
         Printv(imlocals, "\n", im_return_str, " :: fresult", NULL);
     }
 
@@ -1317,6 +1320,7 @@ void FORTRAN::proxyfuncWrapper(Node *n)
     // Replace any instance of $fclassname in return type
     String* cpp_return_type = Getattr(n, "type");
     this->replace_fclassname(cpp_return_type, f_return_str);
+    this->replace_fclassname(cpp_return_type, im_return_str);
 
     // String for calling the im wrapper on the fortran side (the "action")
     String* fcall  = NewStringEmpty();
@@ -1432,7 +1436,6 @@ void FORTRAN::proxyfuncWrapper(Node *n)
         // >>> F PROXY CONVERSION
 
         String* fin = get_typemap("fin", p, WARN_TYPEMAP_IN_UNDEF);
-        this->replace_fclassname(cpptype, fin);
         Replaceall(fin, "$input", farg);
         Printv(ffunc->code, fin, "\n", NULL);
 

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -1201,7 +1201,8 @@ void FORTRAN::imfuncWrapper(Node *n)
     Hash* imimport_hash = NewHash();
 
     // If return type is a fortran C-bound type, add import statement
-    String* imimport = Swig_typemap_lookup("imimport", n, im_return_str, NULL);
+    String* imimport = Swig_typemap_lookup("imimport", n, cpp_return_type,
+                                           NULL);
     if (imimport)
     {
         this->replace_fclassname(cpp_return_type, imimport);


### PR DESCRIPTION
Implement #11 . Given the `%fortran_bindc_struct(classname);` SWIG directive on a struct with no inheritance or member functions, we will generate a `type, BIND(C)` equivalent.