### PR TITLE
Fix INTENT keyword

### DIFF
--- a/Examples/test-suite/common.mk
+++ b/Examples/test-suite/common.mk
@@ -94,13 +94,6 @@ CPP_TEST_BROKEN += \
 	template_expr \
 	$(CPP11_TEST_BROKEN)
 
-# Boost requirements
-FAILING_CPP_TESTS += director_smartptr \
-	li_boost_shared_ptr \
-	li_boost_shared_ptr_attribute \
-	li_boost_shared_ptr_bits \
-	li_boost_shared_ptr_director \
-	li_boost_shared_ptr_template \
 
 # Broken C test cases. (Can be run individually using: make testcase.ctest)
 C_TEST_BROKEN += \

--- a/Examples/test-suite/fortran/li_boost_shared_ptr_runme.f90
+++ b/Examples/test-suite/fortran/li_boost_shared_ptr_runme.f90
@@ -1,0 +1,35 @@
+! File : li_boost_shared_ptr_runme.f90
+
+#include "fassert.h"
+
+program li_boost_shared_ptr_runme
+  use ISO_C_BINDING
+  implicit none
+  call test_ptrs
+
+contains
+
+subroutine test_ptrs
+  use li_boost_shared_ptr
+  use ISO_C_BINDING
+  implicit none
+
+  class(Klass), allocatable :: k
+  class(Klass2ndDerived), allocatable :: ksub
+
+  allocate(k, source=Klass2ndDerived("poop on a stick"))
+  allocate(ksub, source=Klass2ndDerived("two poops"))
+
+  write (*,*) use_count(k)
+  write (*,*) overload_rawbyval(k)
+  write (*,*) overload_smartbyval(k)
+  write (*,*) overload_smartbyref(k)
+
+  write (*,*) use_count(ksub)
+  write (*,*) overload_rawbyval(ksub)
+
+  ! ASSERT(use_count(k) == 1)
+
+end subroutine
+end program
+

--- a/Examples/test-suite/fortran/li_boost_shared_ptr_runme.f90
+++ b/Examples/test-suite/fortran/li_boost_shared_ptr_runme.f90
@@ -26,7 +26,7 @@ subroutine test_ptrs
   write (*,*) overload_smartbyref(k)
 
   write (*,*) use_count(ksub)
-  write (*,*) overload_rawbyval(ksub)
+  write (*,*) overload_smartbyval(ksub)
 
   ! ASSERT(use_count(k) == 1)
 

--- a/Examples/test-suite/li_boost_shared_ptr.i
+++ b/Examples/test-suite/li_boost_shared_ptr.i
@@ -252,6 +252,8 @@ SwigBoost::shared_ptr<Klass>* smartpointerpointerownertest() {
 
 // Provide overloads for Klass and derived classes as some language modules, eg Python, create an extra reference in
 // the marshalling if an upcast to a base class is required.
+// Fortran can't overload class(Derived) with class(Base).
+#ifndef SWIGFORTRAN
 long use_count(const SwigBoost::shared_ptr<Klass3rdDerived>& sptr) {
   return sptr.use_count();
 }
@@ -261,6 +263,7 @@ long use_count(const SwigBoost::shared_ptr<Klass2ndDerived>& sptr) {
 long use_count(const SwigBoost::shared_ptr<KlassDerived>& sptr) {
   return sptr.use_count();
 }
+#endif
 long use_count(const SwigBoost::shared_ptr<Klass>& sptr) {
   return sptr.use_count();
 }

--- a/Examples/test-suite/li_boost_shared_ptr.i
+++ b/Examples/test-suite/li_boost_shared_ptr.i
@@ -44,7 +44,7 @@
 # define SWIG_SHARED_PTR_NAMESPACE SwigBoost
 #endif
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY) || defined(SWIGFORTRAN)
 #define SHARED_PTR_WRAPPERS_IMPLEMENTED
 #endif
 

--- a/Examples/test-suite/li_boost_shared_ptr_attribute.i
+++ b/Examples/test-suite/li_boost_shared_ptr_attribute.i
@@ -1,6 +1,6 @@
 %module li_boost_shared_ptr_attribute
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY) || defined(SWIGFORTRAN)
 #define SHARED_PTR_WRAPPERS_IMPLEMENTED
 #endif
 

--- a/Examples/test-suite/li_boost_shared_ptr_bits.i
+++ b/Examples/test-suite/li_boost_shared_ptr_bits.i
@@ -1,6 +1,6 @@
 %module li_boost_shared_ptr_bits
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY) || defined(SWIGFORTRAN)
 #define SHARED_PTR_WRAPPERS_IMPLEMENTED
 #endif
 

--- a/Examples/test-suite/li_boost_shared_ptr_director.i
+++ b/Examples/test-suite/li_boost_shared_ptr_director.i
@@ -4,7 +4,7 @@
 #include <boost/shared_ptr.hpp>
 %}
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY) || defined(SWIGR)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY) || defined(SWIGR)  || defined(SWIGFORTRAN)
 #define SHARED_PTR_WRAPPERS_IMPLEMENTED
 #endif
 

--- a/Examples/test-suite/li_boost_shared_ptr_template.i
+++ b/Examples/test-suite/li_boost_shared_ptr_template.i
@@ -11,26 +11,26 @@
 
   typedef int INTEGER;
 
-  template <class T> 
+  template <class T>
     class Base {
   public:
     virtual T bar() {return 1;}
     virtual ~Base() {}
   };
 
-  template <class T> 
+  template <class T>
     class Derived : public Base<T> {
   public:
     virtual T bar() {return 2;}
   };
-  
+
   INTEGER bar_getter(Base<INTEGER>& foo) {
     return foo.bar();
   }
 
 %}
 
-#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY)
+#if defined(SWIGJAVA) || defined(SWIGCSHARP) || defined(SWIGPYTHON) || defined(SWIGD) || defined(SWIGOCTAVE) || defined(SWIGRUBY)  || defined(SWIGFORTRAN)
 #define SHARED_PTR_WRAPPERS_IMPLEMENTED
 #endif
 
@@ -44,13 +44,13 @@
 
 typedef int INTEGER;
 
-template <class T> 
+template <class T>
 class Base {
   public:
   virtual T bar() {return 1;}
 };
 
-template <class T> 
+template <class T>
 class Derived : public Base<T> {
   public:
   virtual T bar() {return 2;}
@@ -62,7 +62,7 @@ INTEGER bar_getter(Base<INTEGER>& foo) {
 
 %template(BaseINTEGER) Base<INTEGER>;
 %template(DerivedINTEGER) Derived<INTEGER>;
- 
+
 
 // 2nd test - templates with default template parameters
 #if defined(SHARED_PTR_WRAPPERS_IMPLEMENTED)
@@ -76,19 +76,19 @@ INTEGER bar_getter(Base<INTEGER>& foo) {
 %inline %{
 namespace Space {
 typedef int INT_TYPEDEF;
-template <class X, class T = int> 
+template <class X, class T = int>
 class BaseDefault {
   public:
   virtual T bar2() {return 3;}
   virtual ~BaseDefault() {}
 };
 
-template <class X, class T = int> 
+template <class X, class T = int>
 class DerivedDefault : public BaseDefault<X, T> {
   public:
   virtual T bar2() {return 4;}
 };
-template <class X> 
+template <class X>
 class DerivedDefault2 : public BaseDefault<X> {
   public:
   virtual int bar2() {return 4;}
@@ -103,4 +103,4 @@ int bar2_getter(BaseDefault<short>& foo) {
 %template(BaseDefaultInt) Space::BaseDefault<short>;
 %template(DerivedDefaultInt) Space::DerivedDefault<short>;
 %template(DerivedDefaultInt2) Space::DerivedDefault2<short>;
- 
+

--- a/Lib/fortran/boost_shared_ptr.i
+++ b/Lib/fortran/boost_shared_ptr.i
@@ -38,9 +38,9 @@
  * Deferred copy of basic settings from non-SP type (i.e. Fortran will see it the same; we override the in/out/ctype below)
  */
 
-%typemap(ftype, out={$typemap(ftype, TYPE)}, noblock=1) SWIGSP__, SWIGSP__ &, SWIGSP__ *, SWIGSP__ *&
+%typemap(ftype, in={$typemap(ftype, TYPE*), intent(INOUT)}, noblock=1) SWIGSP__, SWIGSP__ &, SWIGSP__ *, SWIGSP__ *&
   {$typemap(ftype, TYPE*)}
-%typemap(ftype, out={$typemap(ftype, TYPE)}, noblock=1)
+%typemap(ftype, in={$typemap(ftype, TYPE*), intent(IN)}, noblock=1)
     const SWIGSP__ &, const SWIGSP__ *, const SWIGSP__ *&
   {$typemap(ftype, const TYPE*)}
 

--- a/Lib/fortran/boost_shared_ptr.i
+++ b/Lib/fortran/boost_shared_ptr.i
@@ -23,6 +23,8 @@
  *
  */
 #define SWIGSP__ SWIG_SHARED_PTR_QNAMESPACE::shared_ptr<CONST TYPE >
+#define SWIGSP_PTRS__ SWIGSP__ &, SWIGSP__ *
+#define SWIGSP_CPTRS__ const SWIGSP__ &, const SWIGSP__ *
 
 /* -------------------------------------------------------------------------
  * Shared pointers *always* return either NULL or a newly allocated shared
@@ -38,10 +40,9 @@
  * Deferred copy of basic settings from non-SP type (i.e. Fortran will see it the same; we override the in/out/ctype below)
  */
 
-%typemap(ftype, in={$typemap(ftype, TYPE*), intent(INOUT)}, noblock=1) SWIGSP__, SWIGSP__ &, SWIGSP__ *, SWIGSP__ *&
+%typemap(ftype, in={$typemap(ftype, TYPE*)}, noblock=1) SWIGSP__, SWIGSP_PTRS__
   {$typemap(ftype, TYPE*)}
-%typemap(ftype, in={$typemap(ftype, TYPE*), intent(IN)}, noblock=1)
-    const SWIGSP__ &, const SWIGSP__ *, const SWIGSP__ *&
+%typemap(ftype, in={$typemap(ftype, TYPE*)}, noblock=1) SWIGSP_CPTRS__
   {$typemap(ftype, const TYPE*)}
 
 /* -------------------------------------------------------------------------
@@ -51,7 +52,7 @@
  */
 
 %typemap(ctype, in="const SwigClassWrapper *", null="SwigClassWrapper_uninitialized()", noblock=1, fragment="SwigClassWrapper")
-    SWIGSP__, SWIGSP__ &, SWIGSP__ *, SWIGSP__ *&, const SWIGSP__ &, const SWIGSP__ *, const SWIGSP__ *&
+    SWIGSP__, SWIGSP_PTRS__, SWIGSP_CPTRS__
 "SwigClassWrapper"
 
 /* -------------------------------------------------------------------------
@@ -141,7 +142,8 @@
 }
 
 %typemap(out, noblock=1, fragment="SWIG_null_deleter") SWIGSP__ * {
-  $result = ($1 && SWIG_SHARED_PTR_NOT_NULL(*$1)) ? new $*1_ltype(*($1_ltype)$1) : 0;
+  $result.cptr = ($1 && SWIG_SHARED_PTR_NOT_NULL(*$1)) ? new $*1_ltype(*($1_ltype)$1) : 0;
+  $result.mem = SWIG_MOVE;
   if ($owner) delete $1;
 }
 
@@ -176,6 +178,8 @@
  * Clean up macros
  */
 #undef SWIGSP__
+#undef SWIGSP_PTRS__
+#undef SWIGSP_CPTRS__
 
 %enddef
 

--- a/Lib/fortran/boost_shared_ptr.i
+++ b/Lib/fortran/boost_shared_ptr.i
@@ -40,9 +40,9 @@
  * Deferred copy of basic settings from non-SP type (i.e. Fortran will see it the same; we override the in/out/ctype below)
  */
 
-%typemap(ftype, in={$typemap(ftype, TYPE*)}, noblock=1) SWIGSP__, SWIGSP_PTRS__
+%typemap(ftype, in={$typemap(ftype:in, TYPE*)}, noblock=1) SWIGSP__, SWIGSP_PTRS__
   {$typemap(ftype, TYPE*)}
-%typemap(ftype, in={$typemap(ftype, TYPE*)}, noblock=1) SWIGSP_CPTRS__
+%typemap(ftype, in={$typemap(ftype:in, TYPE*)}, noblock=1) SWIGSP_CPTRS__
   {$typemap(ftype, const TYPE*)}
 
 /* -------------------------------------------------------------------------

--- a/Lib/fortran/boost_shared_ptr.i
+++ b/Lib/fortran/boost_shared_ptr.i
@@ -42,7 +42,7 @@
 
 %typemap(ftype, in={$typemap(ftype:in, TYPE*)}, noblock=1) SWIGSP__, SWIGSP_PTRS__
   {$typemap(ftype, TYPE*)}
-%typemap(ftype, in={$typemap(ftype:in, TYPE*)}, noblock=1) SWIGSP_CPTRS__
+%typemap(ftype, in={$typemap(ftype:in, const TYPE*)}, noblock=1) SWIGSP_CPTRS__
   {$typemap(ftype, const TYPE*)}
 
 /* -------------------------------------------------------------------------

--- a/Lib/fortran/classes.swg
+++ b/Lib/fortran/classes.swg
@@ -581,6 +581,9 @@ SWIGINTERN void SWIG_assign_impl(SwigClassWrapper* self, SwigClassWrapper* other
   SWIG_check_mutable_nonnull(*$input, "$1_type", "$fclassname", "$decl", return $null);
   $1 = %static_cast($input->cptr, $1_ltype);
 }
+
+// Const references are like const pointers; use more restrictive check though
+%apply const SWIGTYPE* { const SWIGTYPE& };
 %typemap(in, noblock=1, fragment="SWIG_check_nonnull") const SWIGTYPE& {
   SWIG_check_nonnull(*$input, "$1_type", "$fclassname", "$decl", return $null);
   $1 = %static_cast($input->cptr, $1_ltype);

--- a/Lib/fortran/fundamental.swg
+++ b/Lib/fortran/fundamental.swg
@@ -216,7 +216,7 @@ end function
   "$typemap(ctype, $*1_ltype)"
 %typemap(imtype, in="$typemap(imtype, $*1_ltype), intent(in)") const FUNDTYPE&
   "$typemap(imtype, $*1_ltype)"
-%typemap(ftype) const FUNDTYPE&
+%typemap(ftype, in={$typemap(ftype, $*1_ltype), intent(in)} ) const FUNDTYPE&
   "$typemap(ftype, $*1_ltype)"
 %typemap(in, noblock=1) const FUNDTYPE& ($*1_ltype temp) {
   temp = %static_cast(*$input, $*1_ltype);

--- a/Source/Swig/typemap.c
+++ b/Source/Swig/typemap.c
@@ -2090,6 +2090,7 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
 	  Printf(stdout, "Swig_typemap_attach_parms:  embedded\n");
 #endif
 	  if (already_substituting < 10) {
+	    char* found_colon;
 	    already_substituting++;
 	    if ((in_typemap_search_multi == 0) && typemap_search_debug) {
 	      String *dtypemap = NewString(dollar_typemap);
@@ -2097,7 +2098,14 @@ static void replace_embedded_typemap(String *s, ParmList *parm_sublist, Wrapper 
 	      Printf(stdout, "  Containing: %s\n", dtypemap);
 	      Delete(dtypemap);
 	    }
-	    Swig_typemap_attach_parms(tmap_method, to_match_parms, f);
+	    found_colon = Strstr(tmap_method, ":");
+	    if (found_colon) {
+	      String *temp_tmap_method = NewStringWithSize(Char(tmap_method), found_colon - Char(tmap_method));
+	      Swig_typemap_attach_parms(temp_tmap_method, to_match_parms, f);
+	      Delete(temp_tmap_method);
+	    } else {
+	      Swig_typemap_attach_parms(tmap_method, to_match_parms, f);
+	    }
 	    already_substituting--;
 
 	    /* Look for the typemap code */

--- a/configure.ac
+++ b/configure.ac
@@ -2715,7 +2715,7 @@ if test x"${FORTRAN}" = xno; then
 else
   if test -n "$FCFLAGS" && test "x$GCC" = xyes; then
     # NOTE: unit tests use C preprocessor, so -cpp must be set
-    FCFLAGS="-std=f2003 -Wall -Wimplicit-procedure -Wimplicit-interface -cpp"
+    FCFLAGS="-std=f2003 -Wall -Wimplicit-procedure -Wimplicit-interface"
   fi
 
   if test "x$FORTRAN" = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -2715,7 +2715,7 @@ if test x"${FORTRAN}" = xno; then
 else
   if test -n "$FCFLAGS" && test "x$GCC" = xyes; then
     # NOTE: unit tests use C preprocessor, so -cpp must be set
-    FCFLAGS="-std=f2003 -Wall -Wimplicit-procedure -Wimplicit-interface"
+    FCFLAGS="-std=f2003 -Wall -Wimplicit-procedure -Wimplicit-interface -cpp"
   fi
 
   if test "x$FORTRAN" = xyes; then


### PR DESCRIPTION
This fixes an issue with shared pointers showing up as `type(foo)` instead of `class(foo)` in function arguments.

@aprokop Hopefully this will get fortrilinos up and running again.