### PR TITLE
Improve enum support

### DIFF
--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -588,8 +588,8 @@ constants that are guaranteed to be compatible with C enumerators. Unlike C++,
 all enumerators in Fortran are anonymous.
 
 To associate a C enumeration name with the Fortran
-generated wrappers, SWIG generates an additional enumeration with the C class
-name and a dummy value of `-1`. The enumeration generated from the C code
+generated wrappers, SWIG generates an integer parameter with the C enumeration
+name. The enumeration generated from the C code
 ```c
 enum MyEnum {
   RED = 0,
@@ -601,17 +601,17 @@ enum MyEnum {
 looks like:
 ```fortran
  enum, bind(c)
-  enumerator :: MyEnum = -1
   enumerator :: RED = 0
-  enumerator :: GREEN = RED + 1
-  enumerator :: BLUE = GREEN + 1
+  enumerator :: GREEN
+  enumerator :: BLUE
   enumerator :: BLACK = -1
  end enum
+ integer, parameter :: MyEnum = kind(RED)
 ```
  
 These enumerators are treated as standard C integers in the C wrapper code
 code. In the Fortran wrapper code, procedures that use the enumeration use the
-type `integer(kind(MyEnum))` to clearly indicate what enum type is required.
+type `integer(MyEnum)` to clearly indicate what enum type is required.
 
 Some C++ enumeration definitions cannot be natively interpreted by a Fortran
 compiler (e.g. `FOO = 0x12,` or `BAR = sizeof(int),`), so these are defined in
@@ -641,9 +641,9 @@ struct MyStruct {
 generates
 ```fortran
 enum, bind(c)
- enumerator :: MyStruct_Foo = -1
  enumerator :: MyStruct_Bar = 0
 end enum
+enumerator :: MyStruct_Foo = -1
 ```
 
 If using C++11, `enum class` will scope the enumerations by the enum class's

--- a/Doc/Manual/src/Fortran.md
+++ b/Doc/Manual/src/Fortran.md
@@ -590,7 +590,7 @@ all enumerators in Fortran are anonymous.
 To associate a C enumeration name with the Fortran
 generated wrappers, SWIG generates an integer parameter with the C enumeration
 name. The enumeration generated from the C code
-```c
+```c++
 enum MyEnum {
   RED = 0,
   GREEN,
@@ -614,14 +614,25 @@ code. In the Fortran wrapper code, procedures that use the enumeration use the
 type `integer(MyEnum)` to clearly indicate what enum type is required.
 
 Some C++ enumeration definitions cannot be natively interpreted by a Fortran
-compiler (e.g. `FOO = 0x12,` or `BAR = sizeof(int),`), so these are defined in
-the C++ wrapper code and _bound_ in the Fortran wrapper code:
+compiler, so these are defined in the C++ wrapper code and _bound_ in the
+Fortran wrapper code.
+```c++
+enum MyWeirdEnum {
+  FOO = 0x12,
+  BAR = sizeof(int)
+};
+```
+becomes
 ```fortran
 integer(C_INT), protected, public, &
-   bind(C, name="swigc_FOO") :: FOO
+   bind(C, name="swigc_MyWeirdEnum_FOO") :: FOO
+integer(C_INT), protected, public, &
+   bind(C, name="swigc_MyWeirdEnum_BAR") :: BAR
+integer, parameter :: MyWeirdEnum = C_INT
 ```
+
 The `%fortranconst` directive can be used to explicitly
-enable and disable treatment of a C++ `enum` as a Fortran enumerator; the
+enable treatment of a C++ `enum` as a Fortran enumerator, and the
 `%nofortranconst` directive forces the values to be wrapped as externally-bound
 C integers. See the section on [global constants](#global-constants) for more
 on this directive.
@@ -641,9 +652,9 @@ struct MyStruct {
 generates
 ```fortran
 enum, bind(c)
- enumerator :: MyStruct_Bar = 0
+ enumerator :: MyStruct_Foo_Bar = 0
 end enum
-enumerator :: MyStruct_Foo = -1
+integer, parameter :: MyStruct_Foo = kind(MyStruct_Foo_Bar)
 ```
 
 If using C++11, `enum class` will scope the enumerations by the enum class's
@@ -656,9 +667,9 @@ enum class Foo {
 becomes
 ```fortran
 enum, bind(c)
- enumerator :: Foo = -1
  enumerator :: Foo_Bar = 0
 end enum
+integer, parameter :: Foo = kind(Foo_Bar)
 ```
 
 ## Function pointers

--- a/Examples/test-suite/fortran/Makefile.in
+++ b/Examples/test-suite/fortran/Makefile.in
@@ -54,8 +54,6 @@ FAILING_CPP_TESTS += \
   director_default \
   director_detect \
   director_overload2 \
-  enum_scope_template \
-  enum_thorough \
   extend_default \
   fvirtual \
   inherit_target_language \

--- a/Examples/test-suite/fortran/enum_thorough_runme.F90
+++ b/Examples/test-suite/fortran/enum_thorough_runme.F90
@@ -1,0 +1,21 @@
+! File : enum_thorough_runme.F90
+
+#include "fassert.h"
+
+program enum_thorough_runme
+  use enum_thorough
+  use ISO_C_BINDING
+  implicit none
+  ! Test that the enum type is created 
+  integer(IgnoreTest_ignoreA) :: val
+
+  ! Test that ignoring values preserves later values
+  ASSERT(IgnoreTest_ignoreA_zero == 0)
+  ASSERT(IgnoreTest_ignoreA_three == 3)
+  ASSERT(IgnoreTest_ignoreA_thirty_two == 32)
+
+  val = ignoreATest(IgnoreTest_ignoreA_three)
+  ASSERT(val == 3)
+end program
+
+

--- a/Examples/test-suite/fortran/enums_runme.F90
+++ b/Examples/test-suite/fortran/enums_runme.F90
@@ -20,8 +20,8 @@ program enums_runme
   ASSERT(globalinstance1 == 0)
   ASSERT(globalinstance3 == 30)
 
-  ASSERT(iFoo_Phoo == 50)
-  ASSERT(iFoo_Char == IACHAR('a'))
+  ASSERT(Phoo == 50)
+  ASSERT(Char == IACHAR('a'))
 
   ASSERT(slap == 10)
   ASSERT(mine == 11)

--- a/Examples/test-suite/fortran/enums_runme.F90
+++ b/Examples/test-suite/fortran/enums_runme.F90
@@ -6,7 +6,7 @@ program enums_runme
   use enums
   use ISO_C_BINDING
   implicit none
-  integer(kind(foo1)) :: foo1_val
+  integer(foo1) :: foo1_val
 
   foo1_val = CSP_ITERATION_FWD 
   ASSERT(CSP_ITERATION_FWD == 0)

--- a/Examples/test-suite/fortran/enums_runme.F90
+++ b/Examples/test-suite/fortran/enums_runme.F90
@@ -1,0 +1,31 @@
+! File : enums_runme.F90
+
+#include "fassert.h"
+
+program enums_runme
+  use enums
+  use ISO_C_BINDING
+  implicit none
+  integer(kind(foo1)) :: foo1_val
+
+  foo1_val = CSP_ITERATION_FWD 
+  ASSERT(CSP_ITERATION_FWD == 0)
+  ASSERT(CSP_ITERATION_BWD == 11)
+  call bar1(CSP_ITERATION_FWD)
+
+  ASSERT(ABCDE == 0)
+  ASSERT(FGHJI == 1)
+  call bar2(ABCDE)
+
+  ASSERT(globalinstance1 == 0)
+  ASSERT(globalinstance3 == 30)
+
+  ASSERT(iFoo_Phoo == 50)
+  ASSERT(iFoo_Char == IACHAR('a'))
+
+  ASSERT(slap == 10)
+  ASSERT(mine == 11)
+  ASSERT(thigh == 12)
+end program
+
+

--- a/Examples/test-suite/fortran/enums_runme.F90
+++ b/Examples/test-suite/fortran/enums_runme.F90
@@ -28,4 +28,3 @@ program enums_runme
   ASSERT(thigh == 12)
 end program
 
-

--- a/Examples/test-suite/fortran/fortran_global_const_runme.F90
+++ b/Examples/test-suite/fortran/fortran_global_const_runme.F90
@@ -42,12 +42,11 @@ subroutine test_enums
   use fortran_global_const
   use ISO_C_BINDING
   implicit none
-  integer(C_INT), dimension(4), parameter :: compiletime_enums &
-    = [ NativeEnum, Alfa, Sierra, Juliet ]
+  integer(NativeEnum), dimension(3), parameter :: compiletime_enums &
+    = [ Alfa, Sierra, Juliet ]
 
-  ASSERT(compiletime_enums(1) == -1)
-  ASSERT(compiletime_enums(2) == 0)
-  ASSERT(compiletime_enums(3) == 1)
+  ASSERT(compiletime_enums(1) == 0)
+  ASSERT(compiletime_enums(2) == 1)
 
   ! Runtime enums
 

--- a/Lib/fortran/enums.swg
+++ b/Lib/fortran/enums.swg
@@ -3,9 +3,7 @@
  * ------------------------------------------------------------------------- */
 
 %fragment("SwigUnknownEnum_f", "fpublic", noblock=1) {
-enum, bind(c)
-  enumerator :: SwigUnknownEnum = -1
-end enum
+integer, parameter :: SwigUnknownEnum = C_INT
 }
 
 /* -------------------------------------------------------------------------
@@ -17,8 +15,8 @@ end enum
 // integer pointers)
 FORT_UNSIGNED_TYPEMAP(int, enum SWIGTYPE)
 
-%typemap(ftype, in="integer(kind($fenumname)), intent(in)") enum SWIGTYPE
-  "integer(kind($fenumname))"
+%typemap(ftype, in="integer($fenumname), intent(in)") enum SWIGTYPE
+  "integer($fenumname)"
 %typemap(out, noblock=1) enum SWIGTYPE {
   $result = %static_cast($1, int);
 }

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2178,9 +2178,6 @@ int FORTRAN::enumDeclaration(Node *n) {
 
       Printv(f_fparams, " integer, parameter :: ",  enum_name,
              " = kind(", First(d_enum_public).item, ")\n", NULL);
-
-      // Clean up
-      Delete(enum_name);
     }
 
     // Make the enum class *and* its values public
@@ -2191,7 +2188,18 @@ int FORTRAN::enumDeclaration(Node *n) {
     // Clean up
     Delete(d_enum_public);
     d_enum_public = NULL;
+  } else if (enum_name) {
+    // Create "kind=" value for the enumeration type
+    Printv(f_fpublic, " public :: ", enum_name, "\n", NULL);
+    Printv(f_fparams, " integer, parameter :: ",  enum_name,
+           " = C_INT\n", NULL);
+
+    // Mark that the enum is available for use as a type
+    SetFlag(n, "fortran:declared");
   }
+
+  // Clean up
+  Delete(enum_name);
 
   return SWIG_OK;
 }

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -2158,10 +2158,10 @@ int FORTRAN::enumDeclaration(Node *n) {
     // Create enumerator statement and initialize list of enum values
     d_enum_public = NewList();
     Printv(f_fparams, " enum, bind(c)\n", NULL);
-  }
 
-  // Mark that the enum is available for use as a type
-  SetFlag(n, "fortran:declared");
+    // Mark that the enum is available for use as a type
+    SetFlag(n, "fortran:declared");
+  }
 
   // Emit enum items
   Language::enumDeclaration(n);

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -744,11 +744,11 @@ void FORTRAN::write_module(String *filename) {
            NULL);
   }
 
-  if (Len(f_fparams) > 0) {
-    Printv(out, "\n ! PARAMETERS\n", f_fparams, NULL);
-  }
   if (Len(f_ftypes) > 0) {
     Printv(out, "\n ! TYPES\n", f_ftypes, "\n", NULL);
+  }
+  if (Len(f_fparams) > 0) {
+    Printv(out, "\n ! PARAMETERS\n", f_fparams, NULL);
   }
   if (Len(f_finterfaces) > 0) {
     Printv(out,

--- a/Source/Modules/fortran.cxx
+++ b/Source/Modules/fortran.cxx
@@ -145,8 +145,9 @@ bool is_native_enum(Node *n) {
   if (!enum_feature) {
     // Determine from enum values
     for (Node *c = firstChild(n); c; c = nextSibling(c)) {
-      if (Getattr(c, "error") || GetFlag(c, "feature:ignore"))
-        continue;
+      if (Getattr(c, "error") || GetFlag(c, "feature:ignore")) {
+        return false;
+      }
 
       String *enum_value = Getattr(c, "enumvalue");
       if (enum_value && !is_fortran_intexpr(enum_value)) {


### PR DESCRIPTION
- Remove goofy `= -1` from enum definitions
- Use default fortran C-like behavior (first one is zero and blank means previous plus one) instead of explicitly filling in values
- More consistent definition of enum name
- Fix enum types in template classes being used before `%template`